### PR TITLE
protocol: allow names to expire

### DIFF
--- a/protocol/update_queue_test.go
+++ b/protocol/update_queue_test.go
@@ -52,11 +52,11 @@ func TestUpdateQueue_Enqueue_InvalidBeforeEnqueue(t *testing.T) {
 		if err := store.BanName(tx, "banned"); err != nil {
 			return err
 		}
-		if err := store.SetNameInfoTx(tx, "banned", pub, 10); err != nil {
+		if err := store.SetNameInfoTx(tx, "banned", pub, 10, false); err != nil {
 			return err
 		}
 		for _, header := range headers {
-			if err := store.SetNameInfoTx(tx, header.Name, pub, 10); err != nil {
+			if err := store.SetNameInfoTx(tx, header.Name, pub, 10, false); err != nil {
 				return err
 			}
 			if err := store.SetHeaderTx(tx, header, blob.ZeroSectorHashes); err != nil {
@@ -129,7 +129,7 @@ func TestUpdateQueue_Enqueue_InvalidAfterEnqueue(t *testing.T) {
 		if err := store.SetInitialImportCompleteTx(tx); err != nil {
 			return err
 		}
-		if err := store.SetNameInfoTx(tx, header.Name, pub, 10); err != nil {
+		if err := store.SetNameInfoTx(tx, header.Name, pub, 10, false); err != nil {
 			return err
 		}
 		if err := store.SetHeaderTx(tx, header, blob.ZeroSectorHashes); err != nil {
@@ -167,7 +167,7 @@ func TestUpdateQueue_EnqueueDequeue(t *testing.T) {
 		if err := store.SetInitialImportCompleteTx(tx); err != nil {
 			return err
 		}
-		if err := store.SetNameInfoTx(tx, header.Name, pub, 10); err != nil {
+		if err := store.SetNameInfoTx(tx, header.Name, pub, 10, false); err != nil {
 			return err
 		}
 		if err := store.SetHeaderTx(tx, header, blob.ZeroSectorHashes); err != nil {

--- a/protocol/updater_test.go
+++ b/protocol/updater_test.go
@@ -115,7 +115,7 @@ func TestUpdater(t *testing.T) {
 					if err := store.SetInitialImportCompleteTx(tx); err != nil {
 						return err
 					}
-					if err := store.SetNameInfoTx(tx, name, setup.tp.RemoteSigner.Pub(), 10); err != nil {
+					if err := store.SetNameInfoTx(tx, name, setup.tp.RemoteSigner.Pub(), 10, false); err != nil {
 						return err
 					}
 					return nil
@@ -193,7 +193,7 @@ func TestUpdater(t *testing.T) {
 				// above), so it generates an invalid signature.
 				require.NoError(t, store.WithTx(setup.ls.DB, func(tx *leveldb.Transaction) error {
 					// TODO: ideally setup a fake signer
-					if err := store.SetNameInfoTx(tx, name, setup.tp.LocalSigner.Pub(), 10); err != nil {
+					if err := store.SetNameInfoTx(tx, name, setup.tp.LocalSigner.Pub(), 10, false); err != nil {
 						return err
 					}
 					return nil
@@ -386,7 +386,7 @@ func TestUpdater(t *testing.T) {
 				if err := store.SetInitialImportCompleteTx(tx); err != nil {
 					return err
 				}
-				if err := store.SetNameInfoTx(tx, name, testPeers.RemoteSigner.Pub(), 10); err != nil {
+				if err := store.SetNameInfoTx(tx, name, testPeers.RemoteSigner.Pub(), 10, false); err != nil {
 					return err
 				}
 				return nil
@@ -655,7 +655,7 @@ func TestEpoch(t *testing.T) {
 				if err := store.SetInitialImportCompleteTx(tx); err != nil {
 					return err
 				}
-				if err := store.SetNameInfoTx(tx, name, testPeers.RemoteSigner.Pub(), 10); err != nil {
+				if err := store.SetNameInfoTx(tx, name, testPeers.RemoteSigner.Pub(), 10, false); err != nil {
 					return err
 				}
 				return nil

--- a/store/naming_test.go
+++ b/store/naming_test.go
@@ -2,9 +2,10 @@ package store
 
 import (
 	"fnd/testutil/testcrypto"
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	"github.com/syndtr/goleveldb/leveldb"
-	"testing"
 )
 
 func TestNaming_Meta(t *testing.T) {
@@ -32,7 +33,7 @@ func TestNaming_GetSetNameInfo(t *testing.T) {
 
 	_, pub := testcrypto.RandKey()
 	require.NoError(t, WithTx(db, func(tx *leveldb.Transaction) error {
-		return SetNameInfoTx(tx, "foo", pub, 10)
+		return SetNameInfoTx(tx, "foo", pub, 10, false)
 	}))
 	info, err = GetNameInfo(db, "foo")
 	require.NoError(t, err)
@@ -68,7 +69,7 @@ func TestNaming_StreamNameInfo(t *testing.T) {
 	}
 	require.NoError(t, WithTx(db, func(tx *leveldb.Transaction) error {
 		for _, item := range items {
-			require.NoError(t, SetNameInfoTx(tx, item.Name, item.PublicKey, item.ImportHeight))
+			require.NoError(t, SetNameInfoTx(tx, item.Name, item.PublicKey, item.ImportHeight, item.Expired))
 		}
 		return nil
 	}))


### PR DESCRIPTION
This PR updates `NameInfo` to add a bool which indicates whether the name has expired. Expired names will not propogate updates and will eventually drop from the network until they are renewed again. A name is forced to expire when it's `REVOKE`ed on chain.